### PR TITLE
General tools based on inspect/AST

### DIFF
--- a/codemodel/asttools.py
+++ b/codemodel/asttools.py
@@ -56,7 +56,25 @@ def organize_parameter_names(func):
     """Organize the parameter names by how they will be displayed.
 
     This prefers to use keywords whenever possible (compared to
-    inspect.BoundParameters, which seems to prefer positional arguments).
+    inspect.BoundParameters, which prefers positional arguments).
+
+    Parameters
+    ----------
+    func : callable
+        callable to analyze
+
+    Returns
+    -------
+    as_pos : list of str
+        names of parameters to treat as positional
+    var_pos : str
+        parameter name for variadic positional arguments (usually ``args``),
+        or None if no variadic positional arguments
+    as_kw : list of str
+        names of parameters to treat as keywords
+    var_kw : str
+        parameter name for variadic keyword arguments (usually ``kwargs``),
+        or None if no variadic keywork arguments
     """
     sig = inspect.signature(func)
     param_kinds = collections.defaultdict(list)
@@ -89,6 +107,22 @@ def organize_parameter_names(func):
     return as_pos, var_pos, as_kw, var_kw
 
 def get_args_kwargs(func, param_dict):
+    """Get *args and **kwargs appropriate to do func(*args, **kwargs).
+
+    This uses our preference for keywords over positional arguments.
+
+    Parameters
+    ----------
+    func : callable
+    param_dict : dict
+        mapping of the string parameter name to the associated value, where
+        the parameter name is as given in the func's definition.
+
+    Returns
+    -------
+    args, kwargs : tuple of list, dict
+        appropriate results for func(*args, **kwargs)
+    """
     as_pos, var_pos, as_kw, var_kw = organize_parameter_names(func)
     args = [param_dict[p] for p in as_pos]
     if var_pos:
@@ -100,24 +134,53 @@ def get_args_kwargs(func, param_dict):
 
 
 def deindented_source(src):
+    """De-indent source if all lines indented.
+
+    This is necessary before parsing with ast.parse to avoid "unexpected
+    indent" syntax errors if the function is not module-scope in its
+    original implementation (e.g., staticmethods encapsulated in classes).
+
+    Parameters
+    ----------
+    src : str
+        input source
+
+    Returns
+    -------
+    str :
+        de-indented source; the first character of at least one line is
+        non-whitespace, and all other lines are deindented by the same
+    """
     lines = src.splitlines()
     min_chars_whitespace = float("inf")
     for line in lines:
         if line:
             idx = 0
+            # we're Python 3, so we assume you're not mixing tabs and spaces
             while idx < min_chars_whitespace and line[idx] in [" ", '\t']:
                 idx += 1
 
             min_chars_whitespace = min(idx, min_chars_whitespace)
 
-    print(min_chars_whitespace)
     lines = [line[min_chars_whitespace:] for line in lines]
     src = "\n".join(lines)
     return src
 
 
 def is_return_dict_function(func):
-    """Check whether a function returns a dictionary"""
+    """Check whether a function returns a dictionary
+
+    This assumes that the function is single-return.
+
+    Parameters
+    ----------
+    func : callable
+        a single-return functions
+
+    Returns
+    bool :
+        whether the function returns a dict
+    """
     tree = ast.parse(deindented_source(inspect.getsource(func)))
     func_body = tree.body[0].body
     for node in func_body:
@@ -125,3 +188,20 @@ def is_return_dict_function(func):
             return True
 
     return False
+
+
+def return_dict_func_to_ast_body(func):
+    """
+    Take a function that returns a dict and prepares it for the body.
+    """
+    pass
+
+def instantiation_func_to_ast(func):
+    """
+    """
+    pass
+
+def create_call_ast(func, param_dict, assign=None, prefix=None):
+    """
+    """
+    pass

--- a/codemodel/asttools.py
+++ b/codemodel/asttools.py
@@ -1,0 +1,40 @@
+import ast
+import collections
+import inspect
+
+def bind_arguments(func, param_dict):
+    sig = inspect.signature(func)
+    param_kinds = collections.defaultdict(list)
+
+    for name, param in sig.parameters.items():
+        param_kinds[param.kind].append(name)
+
+    def kind_to_list(kind):
+        return [param_dict[p] for p in param_kinds[kind]]
+
+    def kind_to_dict(kind):
+        return {p: param_dict[p] for p in param_kinds[kind]}
+
+    pos_only = kind_to_list(inspect.Parameter.POSITIONAL_ONLY)
+    varpos_list = kind_to_list(inspect.Parameter.VAR_POSITIONAL)
+    pos_kw = kind_to_dict(inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    kw_only = kind_to_dict(inspect.Parameter.KEYWORD_ONLY)
+    varkw_list = kind_to_dict(inspect.Parameter.VAR_KEYWORD)
+
+    # next two checks should never occur
+    if len(varpos_list) > 1:  # no-cover
+        raise RuntimeError("More than 1 variadic positional argument.")
+
+    if len(varkw_list) > 1:  # no-cover
+        raise RuntimeError("More than 1 variadic keyword argument.")
+
+    varpos = varpos_list[0] if varpos_list else []
+    varkw = list(varkw_list.values())[0] if varkw_list else {}
+
+    if not varpos:
+        bound = sig.bind(*pos_only, **pos_kw, **kw_only, **varkw)
+    else:
+        bound = sig.bind(*pos_only, *pos_kw.values(), *varpos, **kw_only,
+                         **varkw)
+
+    return bound

--- a/codemodel/asttools.py
+++ b/codemodel/asttools.py
@@ -99,9 +99,29 @@ def get_args_kwargs(func, param_dict):
     return args, kwargs
 
 
-def default_call_ast(func, param_dict, prefix=None, assign=None):
-    sig = inspect.signature(func)
-    args = []
-    kwargs = []
+def deindented_source(src):
+    lines = src.splitlines()
+    min_chars_whitespace = float("inf")
+    for line in lines:
+        if line:
+            idx = 0
+            while idx < min_chars_whitespace and line[idx] in [" ", '\t']:
+                idx += 1
 
-    pass
+            min_chars_whitespace = min(idx, min_chars_whitespace)
+
+    print(min_chars_whitespace)
+    lines = [line[min_chars_whitespace:] for line in lines]
+    src = "\n".join(lines)
+    return src
+
+
+def is_return_dict_function(func):
+    """Check whether a function returns a dictionary"""
+    tree = ast.parse(deindented_source(inspect.getsource(func)))
+    func_body = tree.body[0].body
+    for node in func_body:
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict):
+            return True
+
+    return False

--- a/codemodel/asttools.py
+++ b/codemodel/asttools.py
@@ -182,10 +182,10 @@ def create_call_ast(func, param_ast_dict, assign=None, prefix=None):
     ast.AST :
         node that represents this statement
     """
-    args, kwargs = get_args_kwargs(func, param_ast_dict)
-    ast_args = [to_ast(a) for a in args]
+    ast_args, kwargs = get_args_kwargs(func, param_ast_dict)
+    # ast_args = [to_ast(a) for a in args]
     ast_kwargs = [
-        ast.keyword(arg=param, value=to_ast(kwargs[param]))
+        ast.keyword(arg=param, value=kwargs[param])
         for param in kwargs
     ]
     if prefix is not None:
@@ -199,6 +199,8 @@ def create_call_ast(func, param_ast_dict, assign=None, prefix=None):
     if assign is None:
         root_node = func_node
     else:
-        root_node = ast.Assign(target=ast.Name(id=assign, ctx=ast.Store()),
-                               value=func_node)
+        root_node = ast.Assign(
+            targets=[ast.Name(id=assign, ctx=ast.Store())],
+            value=func_node
+        )
     return root_node

--- a/codemodel/tests/test_asttools.py
+++ b/codemodel/tests/test_asttools.py
@@ -1,0 +1,25 @@
+import pytest
+
+from codemodel.asttools import *
+
+
+class FuncSigHolder(object):
+    def foo_pkw(pkw):
+        pass
+
+    def foo_pkw_kw_varkw(pkw, *, kw, **varkw):
+        pass
+
+    def foo_pkw_varpos_kw_varkw(pkw, *varpos, kw, **varkw):
+        pass
+
+@pytest.mark.parametrize("func", [FuncSigHolder.foo_pkw,
+                                  FuncSigHolder.foo_pkw_kw_varkw,
+                                  FuncSigHolder.foo_pkw_varpos_kw_varkw])
+def test_bind_arguments(func):
+    param_dict = {n: n for n in ['p', 'pkw', 'kw']}
+    param_dict.update({'varpos': ('v', 'a', 'r', 'p', 'o', 's'),
+                       'varkw': {'var': 'kw'}})
+    bound = bind_arguments(func, param_dict)
+    for (param, value) in bound.arguments.items():
+        assert value == param_dict[param]

--- a/codemodel/tests/test_asttools.py
+++ b/codemodel/tests/test_asttools.py
@@ -59,6 +59,10 @@ def test_deindented_source(src):
     tree = ast.parse(deindented)
     assert astor.to_source(tree) == not_indented[1:]  # strip leading \n
 
+def test_deindented_source_edge_case():
+    src = "\n".join([" ", "    def foo():", "        pass"])
+    expected = "\n".join(["", "def foo():", "    pass"])
+    assert deindented_source(src) == expected
 
 class ValidateFuncHolder(object):
     def dict_return_global(foo):

--- a/codemodel/tests/test_asttools.py
+++ b/codemodel/tests/test_asttools.py
@@ -15,16 +15,30 @@ class FuncSigHolder(object):
     def foo_pkw_varpos_kw_varkw(pkw, *varpos, kw, **varkw):
         pass
 
-@pytest.mark.parametrize("func", [FuncSigHolder.foo_pkw,
-                                  FuncSigHolder.foo_pkw_kw_varkw,
-                                  FuncSigHolder.foo_pkw_varpos_kw_varkw])
-def test_bind_arguments(func):
-    param_dict = {n: n for n in ['p', 'pkw', 'kw']}
-    param_dict.update({'varpos': ('v', 'a', 'r', 'p', 'o', 's'),
-                       'varkw': {'var': 'kw'}})
-    bound = bind_arguments(func, param_dict)
-    for (param, value) in bound.arguments.items():
-        assert value == param_dict[param]
+@pytest.mark.parametrize("func, results", [
+    (FuncSigHolder.foo_pkw, ([], None, ['pkw'], None)),
+    (FuncSigHolder.foo_pkw_kw_varkw, ([], None, ['pkw', 'kw'], 'varkw')),
+    (FuncSigHolder.foo_pkw_varpos_kw_varkw, (
+        ['pkw'], 'varpos', ['kw'], 'varkw'
+    )),
+])
+def test_organize_parameter_names(func, results):
+    assert organize_parameter_names(func) == results
+
+
+@pytest.mark.parametrize("func, results", [
+    (FuncSigHolder.foo_pkw, ([], {'pkw': 'pkw'})),
+    (FuncSigHolder.foo_pkw_kw_varkw, ([], {'pkw': 'pkw', 'kw': 'kw',
+                                           'var': 'kw'})),
+    (FuncSigHolder.foo_pkw_varpos_kw_varkw, (
+        ['pkw', 'v', 'a', 'r'], {'kw': 'kw', 'var': 'kw'}
+    )),
+])
+def test_get_args_kwargs(func, results):
+    param_dict = {l: l for l in ['p', 'pkw', 'kw']}
+    param_dict.update({'varkw': {'var': 'kw'}, 'varpos': ['v', 'a', 'r']})
+    assert get_args_kwargs(func, param_dict) == results
+
 
 tab_indented = """
 	def indent_test(foo):


### PR DESCRIPTION
This includes:

- [x] Functions for getting args and kwargs, mapping with a preference to assign to kwargs whenever possible.
- [x] Function to get the body of a function that is single-return, returning a dict; and convert that dict to assignments when non-tautological. (Essentially, this lets us take several functions chained by **kwargs as input/output, and make them into a single function.)
- [x] Function to create the AST for calling an arbitrary function, given parameter dictionaries (with values already as AST). Replaces the abstract names in the function with the values in the parameter dictionary. The results can be assigned to a variable name or not. Additionally, a prefix for the function name is possible.
- [x] Function to create the AST from the body of a function, given parameter dictionaries, replacing the abstract names with the values in the dict. Assign or not.
- [x] Tests for all of the above.

This also includes a few `NodeVisitor`/`NodeTransformer`classes. Those may get moved later to put them all in a single file.