### PR TITLE
JSON stack

### DIFF
--- a/codemodel/code_model.py
+++ b/codemodel/code_model.py
@@ -1,0 +1,52 @@
+import importlib
+
+from codemodel import imports
+
+class CodeModel(object):
+    """Model for a callable.
+
+    In simple cases, all you need is an instance of this for each
+    function/class.
+
+    Parameters
+    ----------
+    name : str
+        the name of the callable that this represents
+    parameters : list of :class:`.Parameter`
+        the parameters for this callable
+    package : :class:`.Package`
+        the package where this callable is found
+    """
+    def __init__(self, name, parameters, package=None):
+        self.name = name
+        self.parameters = parameters
+        self.package = package
+
+    # to_dict and from_dict are  not designed for generalized nesting
+    # because, well, why make the effort?
+    def to_dict(self):
+        package_name = self.package.name if self.package else None
+        return {'name': self.name,
+                'parameters': [p.to_dict() for p in self.parameters],
+                'package': package_name}
+
+    @classmethod
+    def from_dict(cls, dct, package=None):
+        dct = dict(dct)  # make a copy
+        params = [codemodel.Parameter.from_dict(p) for p in dct['parameters']]
+        dct['parameters'] = params
+        if package:
+            dct['package'] = package
+        return cls(**dct)
+
+    @property
+    def func(self):
+        """the callable for this code model"""
+        if not self.package:
+            raise RuntimeError("Can't get function without `package` set")
+        imports_dict = imports.import_names(self.package.import_statement)
+        imported_modules = {name: importlib.import_module(mod)
+                            for name, mod in imports_dict.items()}
+        func = getattr(imported_modules[self.package.implicit_prefix],
+                       self.name)
+        return func

--- a/codemodel/code_model.py
+++ b/codemodel/code_model.py
@@ -1,5 +1,6 @@
 import importlib
 
+import codemodel
 from codemodel import imports
 
 class CodeModel(object):
@@ -22,22 +23,30 @@ class CodeModel(object):
         self.parameters = parameters
         self.package = package
 
+    def __hash__(self):
+        return hash((self.name, tuple(self.parameters), self.package))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __repr__(self):  # no-cover
+        repr_str = ("CodeModel(name={c.name}, parameters={c.parameters} "
+                    + "package={c.package})")
+        return repr_str.format(c=self)
+
     # to_dict and from_dict are  not designed for generalized nesting
     # because, well, why make the effort?
     def to_dict(self):
         package_name = self.package.name if self.package else None
         return {'name': self.name,
-                'parameters': [p.to_dict() for p in self.parameters],
-                'package': package_name}
+                'parameters': [p.to_dict() for p in self.parameters]}
 
     @classmethod
     def from_dict(cls, dct, package=None):
         dct = dict(dct)  # make a copy
         params = [codemodel.Parameter.from_dict(p) for p in dct['parameters']]
         dct['parameters'] = params
-        if package:
-            dct['package'] = package
-        return cls(**dct)
+        return cls(**dct, package=package)
 
     @property
     def func(self):

--- a/codemodel/json_stack.py
+++ b/codemodel/json_stack.py
@@ -1,0 +1,124 @@
+import inspect
+
+import codemodel
+
+# extend this if you subclass CodeModel
+CODEMODEL_TYPES = {'CodeModel': codemodel.CodeModel}
+
+class Parameter(object):
+    """A parameter in a callable.
+
+    Wrapper around inspect.Parameter, with our own param_type and desc
+    (instead of the standard Python annotations). The whole thing can be
+    JSON-serialized by way of a dictionary.
+
+    Parameters
+    ----------
+    parameter : inspect.Parameter
+        description of the parameter
+    param_type : str
+        parameter type
+    desc: str
+        string description of this parameter
+    """
+    def __init__(self, parameter, param_type, desc=None):
+        self.parameter = parameter
+        self.param_type = param_type
+        self.desc = desc
+
+    def __repr__(self):
+        return "Parameter({p}, param_type={t}, desc={d})".format(
+            p=repr(self.parameter),
+            t=self.param_type,
+            d=self.desc
+        )
+
+
+    @classmethod
+    def from_values(cls, name, param_type, desc=None,
+                    kind="POSITIONAL_OR_KEYWORD",
+                    default=inspect.Parameter.empty):
+        parameter = inspect.Parameter(
+            name=name,
+            kind=getattr(inspect.Parameter, kind),
+            default=default
+        )
+        return cls(parameter, param_type, desc)
+
+    @property
+    def name(self):
+        return self.parameter.name
+
+    @property
+    def default(self):
+        if not self.has_default:
+            return self.parameter.default
+        else:
+            return None
+
+    @property
+    def has_default(self):
+        return self.parameter.default is not inspect.Parameter.empty
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'param_type': self.param_type,
+            'kind': str(self.parameter.kind),
+            'has_default': self.has_default,
+            'default': self.default,
+            'desc': self.desc
+        }
+
+    @classmethod
+    def from_dict(cls, dct):
+        dct = dict(dct)  # copy
+        has_default = dct.pop('has_default')
+        if not has_default:
+            dct['default'] = inspect.Parameter.empty
+        return cls.from_values(**dct)
+
+    def validate_input(self, inp, validator=None):
+        pass
+
+
+class Package(object):
+    def __init__(self, name, callables, import_statement=None,
+                 implicit_prefix=None, model_types=None):
+        if implicit_prefix is None:
+            implicit_prefix = ""
+
+        if model_types is None:
+            model_types = ["CodeModel"] * len(callables)
+
+        self.name = name
+        self.import_statement = import_statement
+        self.implicit_prefix = implicit_prefix
+        self.callables = callables
+        self.model_types = model_types
+
+    def to_dict(self):
+        return {'name': self.name,
+                'import_statement': self.import_statement,
+                'implicit_prefix': self.implicit_prefix,
+                'model_types': self.model_types,
+                'callables': [c.to_dict() for c in self.callables]
+        }
+
+    @classmethod
+    def from_dict(cls, dct):
+        dct = dict(dct)  # copy
+        dct['callables'] = [
+            CODEMODEL_TYPES[model_t].from_dict(call_dct)
+            for model_t, call_dct in zip(dct['model_types'], dct['callables'])
+        ]
+        return cls(**dct)
+
+
+def load_json(filename):
+    with open(filename, mode='r') as f:
+        dct = json.load(f)
+
+    functions = [Function.from_dict(func_dct)
+                 for func_dct in dct['functions']]
+    return functions

--- a/codemodel/json_stack.py
+++ b/codemodel/json_stack.py
@@ -90,6 +90,24 @@ class Parameter(object):
 class Package(object):
     def __init__(self, name, callables, import_statement=None,
                  implicit_prefix=None, model_types=None):
+        """Container for CodeModel callables, representing a package.
+
+        Parameters
+        ----------
+        name : str
+            package name
+        callables : list of :class:`.CodeModel`
+            callables contained in this package
+        import_statement : str
+            the statemetn used to import the package (e.g., "import sys" or
+            "from os import path")
+        implicit_prefix: str
+            callables are prefixed with this after the import statement,
+            e.g., "import os" as import statement would makethis "os"
+        model_types : list of str
+            string names for CodeModel subclass to be used; one for each
+            callable. Only relevant in event of subclassing.
+        """
         if implicit_prefix is None:
             implicit_prefix = ""
 
@@ -101,6 +119,13 @@ class Package(object):
         self.implicit_prefix = implicit_prefix
         self.callables = callables
         self.model_types = model_types
+
+    def __hash__(self):
+        return hash((self.name, self.import_statement, self.implicit_prefix,
+                     tuple(self.model_types), tuple(self.callables)))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
     def to_dict(self):
         return {'name': self.name,

--- a/codemodel/json_stack.py
+++ b/codemodel/json_stack.py
@@ -26,13 +26,18 @@ class Parameter(object):
         self.param_type = param_type
         self.desc = desc
 
-    def __repr__(self):
+    def __repr__(self):  # no-cover
         return "Parameter({p}, param_type={t}, desc={d})".format(
             p=repr(self.parameter),
             t=self.param_type,
             d=self.desc
         )
 
+    def __hash__(self):
+        return hash((self.parameter, self.param_type, self.desc))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
     @classmethod
     def from_values(cls, name, param_type, desc=None,
@@ -51,7 +56,7 @@ class Parameter(object):
 
     @property
     def default(self):
-        if not self.has_default:
+        if self.has_default:
             return self.parameter.default
         else:
             return None

--- a/codemodel/json_stack.py
+++ b/codemodel/json_stack.py
@@ -1,3 +1,4 @@
+import json
 import inspect
 
 import codemodel
@@ -149,6 +150,4 @@ def load_json(filename):
     with open(filename, mode='r') as f:
         dct = json.load(f)
 
-    functions = [Function.from_dict(func_dct)
-                 for func_dct in dct['functions']]
-    return functions
+    return Package.from_dict(dct)

--- a/codemodel/json_stack.py
+++ b/codemodel/json_stack.py
@@ -147,7 +147,20 @@ class Package(object):
 
 
 def load_json(filename):
-    with open(filename, mode='r') as f:
-        dct = json.load(f)
+    """Load packages from a JSON file.
 
-    return Package.from_dict(dct)
+    Parameters
+    ----------
+    filename : str
+        name of the file to load
+
+    Returns
+    -------
+    list :
+        list of packages in the file
+    """
+    with open(filename, mode='r') as f:
+        json_data = json.load(f)
+
+    packages = [Package.from_dict(dct) for dct in json_data]
+    return packages

--- a/codemodel/tests/test_code_model.py
+++ b/codemodel/tests/test_code_model.py
@@ -1,0 +1,19 @@
+import pytest
+
+from codemodel.code_model import *
+
+class TestCodeModel(object):
+    def setup(self):
+        pass
+
+    def test_to_dict(self):
+        pass
+
+    def test_from_dict(self):
+        pass
+
+    def test_dict_serialize_cycle(self):
+        pass
+
+    def test_func(self):
+        pass

--- a/codemodel/tests/test_code_model.py
+++ b/codemodel/tests/test_code_model.py
@@ -1,19 +1,83 @@
 import pytest
+from unittest import mock
 
+import inspect
+
+import codemodel
 from codemodel.code_model import *
+
+class NameMock(object):
+    # unittest.mock.Mock has a name attribute, so can't mock it out
+    def __init__(self, name):
+        self.name = name
 
 class TestCodeModel(object):
     def setup(self):
-        pass
+        from os.path import exists
+        foo_param = codemodel.Parameter.from_values(name='foo',
+                                                    param_type="Unknown")
+        exists_param = codemodel.Parameter(
+            parameter=inspect.signature(exists).parameters['path'],
+            param_type="Unknown"
+        )
 
-    def test_to_dict(self):
-        pass
+        ospath = mock.Mock(import_statement="from os import path",
+                           implicit_prefix="path",
+                           model_types=['CodeModel'])
 
-    def test_from_dict(self):
-        pass
+        self.packages = {'unpackaged': None, 'packaged': ospath}
 
-    def test_dict_serialize_cycle(self):
-        pass
+        self.models = {
+            'unpackaged': CodeModel(name="func", parameters=[foo_param]),
+            'packaged': CodeModel(name="exists",
+                                  parameters=[exists_param],
+                                  package=ospath)
+        }
+
+        self.dcts = {
+            'unpackaged': {
+                'name': 'func',
+                'parameters': [{'name': 'foo',
+                                'param_type': 'Unknown',
+                                'desc': None,
+                                'kind': "POSITIONAL_OR_KEYWORD",
+                                'default': None,
+                                'has_default': False}],
+            },
+            'packaged': {
+                'name': 'exists',
+                'parameters': [{'name': 'path',
+                                'param_type': 'Unknown',
+                                'desc': None,
+                                'kind': "POSITIONAL_OR_KEYWORD",
+                                'default': None,
+                                'has_default': False}],
+            }
+        }
+
+    @pytest.mark.parametrize("model_name", ["unpackaged", "packaged"])
+    def test_to_dict(self, model_name):
+        assert self.models[model_name].to_dict() == self.dcts[model_name]
+
+    @pytest.mark.parametrize("model", ["unpackaged", "packaged"])
+    def test_from_dict(self, model):
+        pkg = self.packages[model]
+        result = CodeModel.from_dict(self.dcts[model], package=pkg)
+        assert result == self.models[model]
+
+    @pytest.mark.parametrize("model", ["unpackaged", "packaged"])
+    def test_dict_serialize_cycle(self, model):
+        pkg = self.packages[model]
+        serialized = self.models[model].to_dict()
+        deserialized = CodeModel.from_dict(serialized, package=pkg)
+        assert deserialized == self.models[model]
+        reserialized = deserialized.to_dict()
+        assert serialized == reserialized
+
+    def test_func_no_package(self):
+        with pytest.raises(RuntimeError):
+            self.models['unpackaged'].func
 
     def test_func(self):
-        pass
+        import os.path
+        assert self.models['packaged'].func == os.path.exists

--- a/codemodel/tests/test_json_stack.py
+++ b/codemodel/tests/test_json_stack.py
@@ -1,8 +1,9 @@
 import pytest
 import inspect
+import json
+import tempfile
 
 from codemodel.json_stack import *
-
 
 def func(pkw, *, kw='foo', kw2=None):
     # empty function; signature used in testing
@@ -117,5 +118,9 @@ class TestPackage(object):
         reserialized = deserialized.to_dict()
         assert serialized == reserialized
 
-def test_load_json():
-    pass
+    def test_load_json(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", mode='w+') as tmp:
+            json.dump(self.package.to_dict(), tmp)
+            tmp.flush()
+            loaded = load_json(tmp.name)
+            assert loaded == self.package

--- a/codemodel/tests/test_json_stack.py
+++ b/codemodel/tests/test_json_stack.py
@@ -74,14 +74,48 @@ class TestParameter(object):
 
 
 class TestPackage(object):
+    def setup(self):
+        from os.path import exists
+        callables = [codemodel.CodeModel(
+            name="exists",
+            parameters=[Parameter(
+                inspect.signature(exists).parameters['path'],
+                param_type="Unknown"
+            )]
+        )]
+        self.package = Package(name="ospath",
+                               callables=callables,
+                               import_statement="from os import path",
+                               implicit_prefix="path")
+
+        self.dct = {
+            'name': 'ospath',
+            'import_statement': "from os import path",
+            'implicit_prefix': "path",
+            'model_types': ['CodeModel'],
+            'callables': [{
+                'name': 'exists',
+                'parameters': [{'name': 'path',
+                                'param_type': 'Unknown',
+                                'desc': None,
+                                'kind': "POSITIONAL_OR_KEYWORD",
+                                'default': None,
+                                'has_default': False}],
+            }]
+        }
+
     def test_to_dict(self):
-        pass
+        assert self.package.to_dict() == self.dct
 
     def test_from_dict(self):
-        pass
+        assert Package.from_dict(self.dct) == self.package
 
     def test_dict_serialize_cycle(self):
-        pass
+        serialized = self.package.to_dict()
+        deserialized = Package.from_dict(serialized)
+        assert deserialized == self.package
+        reserialized = deserialized.to_dict()
+        assert serialized == reserialized
 
 def test_load_json():
     pass

--- a/codemodel/tests/test_json_stack.py
+++ b/codemodel/tests/test_json_stack.py
@@ -120,7 +120,8 @@ class TestPackage(object):
 
     def test_load_json(self):
         with tempfile.NamedTemporaryFile(suffix=".json", mode='w+') as tmp:
-            json.dump(self.package.to_dict(), tmp)
+            json.dump([self.package.to_dict()], tmp)
             tmp.flush()
             loaded = load_json(tmp.name)
-            assert loaded == self.package
+            assert len(loaded) == 1
+            assert loaded[0] == self.package

--- a/codemodel/tests/test_json_stack.py
+++ b/codemodel/tests/test_json_stack.py
@@ -1,0 +1,87 @@
+import pytest
+import inspect
+
+from codemodel.json_stack import *
+
+
+def func(pkw, *, kw='foo', kw2=None):
+    # empty function; signature used in testing
+    pass
+
+
+class TestParameter(object):
+    def setup(self):
+        self.sig_parameters = inspect.signature(func).parameters
+        self.params = {p.name: Parameter(p, "Unknown")
+                       for p in self.sig_parameters.values()}
+        # create a set of relevant parameters
+        self.dcts = {
+            'pkw': {'name': 'pkw',
+                    'param_type': "Unknown",
+                    'kind': "POSITIONAL_OR_KEYWORD",
+                    'has_default': False,
+                    'default': None,
+                    'desc': None},
+            'kw': {'name': 'kw',
+                   'param_type': "Unknown",
+                   'kind': "KEYWORD_ONLY",
+                   'has_default': True,
+                   'default': 'foo',
+                   'desc': None},
+            'kw2': {'name': 'kw2',
+                    'param_type': "Unknown",
+                    'kind': "KEYWORD_ONLY",
+                    'has_default': True,
+                    'default': None,
+                    'desc': None},
+        }
+        pass
+
+    def test_from_values(self):
+        param = Parameter.from_values(
+            name="pkw",
+            param_type="Unknown"
+        )
+        assert param == self.params['pkw']
+
+    def test_name(self):
+        assert self.params['pkw'].name == 'pkw'
+
+    @pytest.mark.parametrize("name", ['pkw', 'kw', 'kw2'])
+    def test_default(self, name):
+        assert self.params[name].default == self.dcts[name]['default']
+
+    @pytest.mark.parametrize("name", ['pkw', 'kw', 'kw2'])
+    def test_has_default(self, name):
+        assert self.params[name].has_default == self.dcts[name]['has_default']
+
+
+    @pytest.mark.parametrize("name", ['pkw', 'kw', 'kw2'])
+    def test_to_dict(self, name):
+        assert self.params[name].to_dict() == self.dcts[name]
+
+    @pytest.mark.parametrize("name", ['pkw', 'kw', 'kw2'])
+    def test_from_dict(self, name):
+        assert Parameter.from_dict(self.dcts[name]) == self.params[name]
+
+    @pytest.mark.parametrize("name", ['pkw', 'kw', 'kw2'])
+    def test_dict_serialize_cycle(self, name):
+        serialized = self.params[name].to_dict()
+        deserialized = Parameter.from_dict(serialized)
+        assert deserialized == self.params[name]
+        reserialized = deserialized.to_dict()
+        assert serialized == reserialized
+
+
+class TestPackage(object):
+    def test_to_dict(self):
+        pass
+
+    def test_from_dict(self):
+        pass
+
+    def test_dict_serialize_cycle(self):
+        pass
+
+def test_load_json():
+    pass


### PR DESCRIPTION
This adds in the JSON stack, which represents a collection of callables as a JSON dictionary.

- [x] `Parameter`: description of a parameter in the callable
- [x] `CodeModel`: description of the callable; represents classes/functions
- [x] `Package`: container for many callables; represents the package
- [x] `load_json`: function to create a complete `Package` object from the JSON file describing it