### PR TITLE
Pass through parameters

### DIFF
--- a/codemodel/asttools/__init__.py
+++ b/codemodel/asttools/__init__.py
@@ -1,8 +1,8 @@
 from .imports import validate_imports, import_names
 
 from .function_handling import (
-    organize_parameter_names, get_args_kwargs, deindented_source,
-    func_to_body_tree
+    organize_parameter_names, get_args_kwargs, get_unused_params,
+    deindented_source, func_to_body_tree
 )
 from .validators import (
     ScopeTracker, ScopeLister, count_returns,

--- a/codemodel/asttools/function_handling.py
+++ b/codemodel/asttools/function_handling.py
@@ -89,6 +89,25 @@ def get_args_kwargs(func, param_dict):
     inspect.signature(func).bind(*args, **kwargs)  # just to test it
     return args, kwargs
 
+def get_unused_params(func, param_dict):
+    """Return parameters in the param_dict that aren't inputs to func
+
+    Parameters
+    ----------
+    func : Callable[[Any], Any]
+    param_dict : Dict[str, Any]
+        mapping of the string parameter name to the associated value, where
+        the parameter name is as given in the func's definition.
+
+    Returns
+    -------
+    Dict[str, Any] :
+        parameters that aren't inputs to func
+    """
+    func_params = {p for p in inspect.signature(func).parameters}
+    unused = set(param_dict.keys()) - func_params
+    return {k: param_dict[k] for k in unused}
+
 def deindented_source(src):
     """De-indent source if all lines indented.
 

--- a/codemodel/code_model.py
+++ b/codemodel/code_model.py
@@ -222,8 +222,8 @@ class CodeModel(object):
 
         return obj
 
-    def _default_setup_ast(self, param_dict, assign=None):
-        return asttools.create_call_ast(self.func, param_dict,
+    def _default_setup_ast(self, param_ast_dict, assign=None):
+        return asttools.create_call_ast(self.func, param_ast_dict,
                                         assign=assign,
                                         prefix=self.package.implicit_prefix)
 
@@ -234,11 +234,13 @@ class CodeModel(object):
                       for name, param in instance.param_dict.items()}
         ast_sections = {}
         ast_funcs = self._ast_funcs
+        print(params_ast)
         for sec_id, func in self.setup.items():
             if func == self._main_call:
-                sec_ast = ast_funcs[sec_id](params_ast, assign=instance.name)
+                sec_ast = ast_funcs[sec_id](param_ast_dict=params_ast,
+                                            assign=instance.name)
             else:
-                sec_ast = ast_funcs[sec_id](params_ast)
+                sec_ast = ast_funcs[sec_id](param_ast_dict=params_ast)
             ast_sections[sec_id] = sec_ast
 
         return ast_sections

--- a/codemodel/code_model.py
+++ b/codemodel/code_model.py
@@ -203,14 +203,22 @@ class CodeModel(object):
 
         func_param_dict = dict(instance.param_dict)  # copy
 
+        def run_return_dict_func(func, func_param_dict):
+            args, kwargs = asttools.get_args_kwargs(func, func_param_dict)
+            passthrough = asttools.get_unused_params(func, func_param_dict)
+            func_param_dict = func(*args, **kwargs)
+            func_param_dict.update(passthrough)
+            return func_param_dict
+
         for func in self._pre_call:
-            # TODO: fix this for positional arguments
-            func_param_dict = func(**func_param_dict)
+            # func_param_dict = func(**func_param_dict)
+            func_param_dict = run_return_dict_func(func, func_param_dict)
 
         obj = self._main_call(**func_param_dict)
 
         for func in self._post_call:
-            func_param_dict = func(**func_param_dict)
+            func_param_dict = run_return_dict_func(func, func_param_dict)
+            # func_param_dict = func(**func_param_dict)
 
         return obj
 

--- a/codemodel/tests/asttools/test_function_handling.py
+++ b/codemodel/tests/asttools/test_function_handling.py
@@ -32,6 +32,14 @@ def test_get_args_kwargs(func, results):
     param_dict.update({'varkw': {'var': 'kw'}, 'varpos': ['v', 'a', 'r']})
     assert get_args_kwargs(func, param_dict) == results
 
+@pytest.mark.parametrize("param_dict, results", [
+    ({'pkw': 'pkw'}, {}),
+    ({'pkw': 'pkw', 'foo': 'foo'}, {'foo': 'foo'})
+])
+def test_get_unused_params(param_dict, results):
+    func = FuncSigHolder.foo_pkw
+    assert get_unused_params(func, param_dict) == results
+
 
 tab_indented = """
 	def indent_test(foo):

--- a/codemodel/tests/test_code_model.py
+++ b/codemodel/tests/test_code_model.py
@@ -343,7 +343,9 @@ class TestInstance(object):
         }
         self.param_dict = {
             'os.path.exists': {'path': __file__},
-            'pass_through': {'num': '3', 'power': '2'},
+            # TODO: these should be strings, but need to fix up move type
+            # validation back into instantiation for that
+            'pass_through': {'num': 3, 'power': 2},
         }
         self.expected = {
             'os.path.exists': True,
@@ -354,8 +356,8 @@ class TestInstance(object):
                 50: (r"path_exists = path.exists\(path\=\s*'"
                      + str(__file__) + r"'\s*\)")
             },
-            'pass_through': {10: r"data = 3 * 2",
-                             50: r"result = data ** 2"},
+            'pass_through': {10: (r"data = 3 \* 2\s*"),
+                             50: r"result = data \*\* 2\s*"},
         }
         self.instances = {
             'os.path.exists': Instance(

--- a/codemodel/tests/test_code_model.py
+++ b/codemodel/tests/test_code_model.py
@@ -9,6 +9,19 @@ from codemodel.code_model import *
 
 import collections
 
+class PassThroughParameterExample(object):
+    # this takes a param_dict with two parameters, `num` and `power`
+    # TODO: does this also need to be tested if written in AST? I don't
+    # think so; at least, not until/unless we do more significant parameter
+    # checking of the user-provided AST.
+    @staticmethod
+    def prepare(num):
+        return {'data': num * 2}
+
+    @staticmethod
+    def do_power(data, power):
+        return data**power
+
 
 class SectionsExample(object):
     import ast
@@ -295,6 +308,8 @@ class TestInstance(object):
         import os.path
         exists = os.path.exists
 
+        default_kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+
         # TODO: try several more complicated code models
         self.models = {
             'os.path.exists': CodeModel(
@@ -307,18 +322,40 @@ class TestInstance(object):
                                   implicit_prefix="path",
                                   model_types=['CodeModel'])
             ),
+            'pass_through': CodeModel(
+                name="pass_through",
+                parameters=[
+                    codemodel.Parameter(
+                        parameter=inspect.Parameter(name="num",
+                                                    kind=default_kind),
+                        param_type='int'
+                    ),
+                    codemodel.Parameter(
+                        parameter=inspect.Parameter(name="power",
+                                                    kind=default_kind),
+                        param_type='int'
+                    )
+                ],
+                package=None,
+                setup={10: PassThroughParameterExample.prepare,
+                       50: PassThroughParameterExample.do_power}
+            ),
         }
         self.param_dict = {
             'os.path.exists': {'path': __file__},
+            'pass_through': {'num': '3', 'power': '2'},
         }
         self.expected = {
             'os.path.exists': True,
+            'pass_through': (2*3)**2,
         }
         self.expected_code = {
             'os.path.exists': {
                 50: (r"path_exists = path.exists\(path\=\s*'"
                      + str(__file__) + r"'\s*\)")
             },
+            'pass_through': {10: r"data = 3 * 2",
+                             50: r"result = data ** 2"},
         }
         self.instances = {
             'os.path.exists': Instance(
@@ -326,10 +363,18 @@ class TestInstance(object):
                 code_model=self.models['os.path.exists'],
                 param_dict=self.param_dict['os.path.exists']
             ),
+            'pass_through': Instance(
+                name="result",
+                code_model=self.models['pass_through'],
+                param_dict=self.param_dict['pass_through']
+            ),
         }
 
-    def test_instance(self):
-        model_name = 'os.path.exists'
+
+    @pytest.mark.parametrize("model_name", [
+        'os.path.exists', 'pass_through',
+    ])
+    def test_instance(self, model_name):
         model = self.models[model_name]
         instance_obj = self.instances[model_name]
         instance = instance_obj.instance
@@ -345,8 +390,10 @@ class TestInstance(object):
         assert instance_obj.code_name != instance_obj.name
         assert instance_obj.name == old_name
 
-    def test_code_sections(self):
-        model_name = 'os.path.exists'
+    @pytest.mark.parametrize("model_name", [
+        'os.path.exists', 'pass_through',
+    ])
+    def test_code_sections(self, model_name):
         instance_obj = self.instances[model_name]
         code_sections = instance_obj.code_sections
         for sec_id, code in code_sections.items():


### PR DESCRIPTION
Allow unused unused parameters to be passed to a later function, instead of the first in the instantiation sequence. (For fancy setup-based models.) 