### PR TITLE
Fixes for isort 5

### DIFF
--- a/codemodel/script_model.py
+++ b/codemodel/script_model.py
@@ -32,7 +32,7 @@ class BlackFormatter(object):
 class ISortFormatter(object):
     # this is a class in order to allow configuration in the future
    def __call__(self, script):
-        return isort.SortImports(file_contents=script).output
+       return isort.code(code=script)
 
 
 class ScriptModel(object):

--- a/codemodel/tests/test_script_model.py
+++ b/codemodel/tests/test_script_model.py
@@ -110,8 +110,8 @@ class TestScriptModel(object):
 
 def test_isort_formatter():
     formatter = ISortFormatter()
-    input_code = "import sys\nprint('foo')\nimport os"
-    output_code = "import os\nimport sys\n\nprint('foo')\n"
+    input_code = "import sys\nimport os\n"
+    output_code = "import os\nimport sys\n"
     assert formatter(input_code) == output_code
 
 def test_black_formatter():

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 install_requires =
     astor
     black  # TOOD: should be optional
-    isort  # TODO: should be optional
+    isort >= 5  # TODO: should be optional
 packages = find:
 
 [bdist_wheel]


### PR DESCRIPTION
Unfortunately, as of isort 5, it looks like we no longer get to pull imports to the top. Therefore, this will have to become the responsibility of codemodel.